### PR TITLE
Fixed image clipping on smaller mobile screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 ## Welcome! 👋
 
-|      Ahmad Hussain       |    Darionas    |
-| :----------------------: | :------------: |
-|                          | Initial update |
-|                          |    update_1    |
-|                          |    update_2    |
-|                          |    update_3    |
-|                          |    update_4    |
-| CSS for mobile main page |                |
+|             Ahmad Hussain             |    Darionas    |
+| :-----------------------------------: | :------------: |
+|                                       | Initial update |
+|                                       |    update_1    |
+|                                       |    update_2    |
+|                                       |    update_3    |
+|                                       |    update_4    |
+|       CSS for mobile main page        |                |
+| Fixed img clipping on smaller screens |                |
 
 ## Challenge based on
 

--- a/style.css
+++ b/style.css
@@ -33,6 +33,7 @@ body {
 }
 
 .grid-container {
+  width: 100vw;
   max-width: 24rem;
   background-color: var(--white);
 }


### PR DESCRIPTION
Fixed image clipping on smaller mobile screens by adding width: 100vw; to .grid-container.